### PR TITLE
Apply .portalMessage styling to reST admonitions

### DIFF
--- a/plonetheme/sunburst/skins/sunburst_styles/public.css
+++ b/plonetheme/sunburst/skins/sunburst_styles/public.css
@@ -785,7 +785,16 @@ div.listingBar a:hover {
 
 /* @group Status messages */
 
-dl.portalMessage {
+dl.portalMessage,
+div.attention,
+div.caution,
+div.danger,
+div.error,
+div.hint,
+div.important,
+div.note,
+div.tip,
+div.warning {
     margin: 1em 0;
     font-size: 80%;
     border: 1px solid #996;
@@ -793,11 +802,30 @@ dl.portalMessage {
     clear:both;
 }
 dl.portalMessage a,
-#content dl.portalMessage a {
+#content dl.portalMessage a,
+div.attention a,
+div.caution a,
+div.danger a,
+div.error a,
+div.hint a,
+div.important a,
+div.note a,
+div.tip a,
+div.warning a,
+#content div.attention a,
+#content div.caution a,
+#content div.danger a,
+#content div.error a,
+#content div.hint a,
+#content div.important a,
+#content div.note a,
+#content div.tip a,
+#content div.warning a {
     color: black;
     border-bottom: 1px solid #888;
 }
-dl.portalMessage dt {
+dl.portalMessage dt,
+div > .admonition-title {
     background-color: #996;
     font-weight: bold;
     float: left;
@@ -806,45 +834,77 @@ dl.portalMessage dt {
     color: White;
     line-height: 1.25em;
 }
-dl.portalMessage dd {
+dl.portalMessage dd,
+div.attention > .last,
+div.caution > .last,
+div.danger > .last,
+div.error > .last,
+div.hint > .last,
+div.important > .last,
+div.note > .last,
+div.tip > .last,
+div.warning > .last {
     padding: 0.5em 0.5em;
     margin: 0;
     line-height: 1.25em;
 }
-dl.warning {
+.warning {
     border-color: #d80;
 }
-dl.warning dt {
+.warning > dt,
+.warning > .admonition-title {
     background-color: #d80;
 }
-dl.error {
+.error {
     border-color: #d00;
 }
-dl.error dt {
+.error > dt,
+.error > .admonition-title {
     background-color: #d00;
 }
-dl.warning {
+.warning {
     border-color: #d80;
 }
-dl.warning dd {
+.warning > dd,
+.warning > .last {
     background-color: #fd7;
 }
-dl.error {
+.error {
     border-color: red;
 }
-dl.error dd {
+.error > dd,
+.error > .last {
     background-color: #fdc;
 }
 
 /* Additional specificity for when status is shown inside #content */
-#content dl.portalMessage {
+#content dl.portalMessage,
+#content div.attention a,
+#content div.caution a,
+#content div.danger a,
+#content div.error a,
+#content div.hint a,
+#content div.important a,
+#content div.note a,
+#content div.tip a,
+#content div.warning a {
     font-size: 100%;
 }
-#content dl.portalMessage dt {
+#content dl.portalMessage dt,
+#content div > .admonition-title {
     margin: 0 0.5em 0 0;
     padding: 0.5em 0.75em;
 }
-#content dl.portalMessage dd {
+#content dl.portalMessage dd,
+#content div.attention > .last,
+#content div.caution > .last,
+#content div.danger > .last,
+#content div.error > .last,
+#content div.hint > .last,
+#content div.important > .last,
+#content div.note > .last,
+#content div.tip > .last,
+#content div.warning > .last {
     margin: 0;
 }
 


### PR DESCRIPTION
http://docutils.sourceforge.net/docs/ref/rst/directives.html#admonitions

This involves CSS changes that @lukebrannon and I worked on when we realized that reST admonitions are unstyled on OOTB Plone but we're not sure the CSS changes might not interfere somewhere.  Can someone more familiar with Plone's CSS review this.
