### PR TITLE
Word break

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ Changelog
 1.2.7 (unreleased)
 ------------------
 
+- Word-break property on content so text don't overflow to the right column [Tamosauskas]
 - Move new CSS class generation into new function called ``getColumnClasses``
   to let the old and deprecated one return column content CSS class only. This
   is important to keep all previously customized main_templates working.

--- a/plonetheme/sunburst/skins/sunburst_styles/public.css
+++ b/plonetheme/sunburst/skins/sunburst_styles/public.css
@@ -458,6 +458,7 @@ dl.portlet ul.navTree .navTreeCurrentItem {
     clear: both;
     font-size: 80%;
     margin: 1em 0.25em 2em 0.25em;
+    word-break: break-all;
 }
 
 /* Special case of #content - TinyMCE */


### PR DESCRIPTION
Word-break property on content so text don't overflow the right column.
